### PR TITLE
Add PostHog integration and E2E system tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,35 @@
+name: E2E Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  system-tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/backend_test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+      - name: Setup database
+        run: cd apps/backend && bundle exec rails db:prepare
+      - name: Run system tests
+        run: cd apps/backend && bundle exec rails test:system

--- a/apps/backend/Gemfile
+++ b/apps/backend/Gemfile
@@ -54,3 +54,6 @@ gem "rubocop-rspec", "~> 3.6"
 gem "authentication-zero", "~> 4.0"
 gem "rack-cors"
 
+# Analytics
+gem "posthog-ruby", require: false
+

--- a/apps/backend/app/controllers/identity/password_resets_controller.rb
+++ b/apps/backend/app/controllers/identity/password_resets_controller.rb
@@ -10,6 +10,7 @@ class Identity::PasswordResetsController < ApplicationController
   def create
     if @user = User.find_by(email: params[:email], verified: true)
       UserMailer.with(user: @user).password_reset.deliver_later
+      PostHog.capture({ distinct_id: @user.id, event: "password_reset_requested" }) if defined?(PostHog)
     else
       render json: { error: "You can't reset your password until you verify your email" }, status: :bad_request
     end

--- a/apps/backend/app/controllers/registrations_controller.rb
+++ b/apps/backend/app/controllers/registrations_controller.rb
@@ -7,6 +7,7 @@ class RegistrationsController < ApplicationController
     if @user.save
       send_email_verification
       render json: @user, status: :created
+      PostHog.capture({ distinct_id: @user.id, event: "user_signed_up" }) if defined?(PostHog)
     else
       render json: @user.errors, status: :unprocessable_entity
     end

--- a/apps/backend/app/controllers/sessions_controller.rb
+++ b/apps/backend/app/controllers/sessions_controller.rb
@@ -17,6 +17,7 @@ class SessionsController < ApplicationController
       response.set_header "X-Session-Token", @session.signed_id
 
       render json: @session, status: :created
+      PostHog.capture({ distinct_id: user.id, event: "user_logged_in" }) if defined?(PostHog)
     else
       render json: { error: "That email or password is incorrect" }, status: :unauthorized
     end

--- a/apps/backend/config/initializers/posthog.rb
+++ b/apps/backend/config/initializers/posthog.rb
@@ -1,0 +1,9 @@
+begin
+  require 'posthog-ruby'
+  PostHog.configure do |config|
+    config.api_key = ENV['POSTHOG_API_KEY']
+    config.host = ENV.fetch('POSTHOG_API_HOST', 'https://us.posthog.com')
+  end
+rescue LoadError
+  Rails.logger.warn 'PostHog gem not installed, skipping analytics'
+end

--- a/apps/backend/test/application_system_test_case.rb
+++ b/apps/backend/test/application_system_test_case.rb
@@ -1,0 +1,5 @@
+require "test_helper"
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :rack_test
+end

--- a/apps/backend/test/system/authentication_flow_test.rb
+++ b/apps/backend/test/system/authentication_flow_test.rb
@@ -1,0 +1,23 @@
+require "application_system_test_case"
+
+class AuthenticationFlowTest < ApplicationSystemTestCase
+  driven_by :rack_test
+
+  test "user can sign up, log in, and request password reset" do
+    email = "test@example.com"
+    password = "secret123"
+
+    page.driver.post sign_up_path, params: { email:, password:, password_confirmation: password }
+    assert_equal 201, page.status_code
+
+    page.driver.post sign_in_path, params: { email:, password: }
+    assert_equal 201, page.status_code
+    token = page.driver.response.headers["X-Session-Token"]
+    assert token.present?
+
+    assert_emails 1 do
+      page.driver.post identity_password_reset_path, params: { email: }
+      assert_equal 200, page.status_code
+    end
+  end
+end

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-router-dom": "^7.8.1"
+        "react-router-dom": "^7.8.1",
+        "posthog-js": "^1.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -27,6 +28,10 @@
         "tailwindcss": "^3.4.13",
         "vite": "^7.1.2"
       }
+    },
+    "node_modules/posthog-js": {
+      "version": "1.0.0",
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.8.1"
+    "react-router-dom": "^7.8.1",
+    "posthog-js": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/apps/frontend/src/lib/posthog.js
+++ b/apps/frontend/src/lib/posthog.js
@@ -1,0 +1,13 @@
+import posthog from 'posthog-js';
+
+export function initPostHog() {
+  const key = import.meta.env.VITE_POSTHOG_KEY;
+  if (!key) return;
+  posthog.init(key, {
+    api_host: import.meta.env.VITE_POSTHOG_HOST || 'https://us.posthog.com',
+    capture_pageview: true,
+    capture_pageleave: true,
+  });
+}
+
+export default posthog;

--- a/apps/frontend/src/main.jsx
+++ b/apps/frontend/src/main.jsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { initPostHog } from './lib/posthog.js'
+
+initPostHog()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- integrate PostHog on frontend and backend
- add Rails system test covering sign up, login and password reset
- run system tests in CI with GitHub Actions

## Testing
- `npm test` *(fails: Missing script)*
- `bundle exec rails test:system` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_68a85fcab60483228e850dbc16beb752